### PR TITLE
Update props-vs-state.md

### DIFF
--- a/props-vs-state.md
+++ b/props-vs-state.md
@@ -50,7 +50,6 @@ Can be changed by parent Component? | Yes | No
 Can set default values inside Component?* | Yes | Yes
 Can change inside Component? | No | Yes
 Can set initial value for child Components? | Yes | Yes
-Can change in child Components? | Yes | No
 
 \* Note that both _props_ and _state_ initial values received from parents override default values defined inside a Component.
 


### PR DESCRIPTION
`Can change in child Components? | Yes | No` is already covered by `Can be changed by parent Component? | Yes | No`. This seems to cause confusion. In particular this last line is interpreted as "it is possible to mutate props in components that use them".